### PR TITLE
add faster, less allocatey unicode escaper

### DIFF
--- a/src/BalikoBot/BalikoBot.csproj
+++ b/src/BalikoBot/BalikoBot.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -15,6 +15,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageId>BalikoBotSharp</PackageId>
     <Version>1.0.1</Version>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/BalikoBot/BalikobotClient.cs
+++ b/src/BalikoBot/BalikobotClient.cs
@@ -1,4 +1,5 @@
 ﻿using BalikoBot.BO;
+using BalikoBot.Internal;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System;
@@ -402,21 +403,10 @@ namespace BalikoBot
 			var response = await todo(client);
 			var content = await response.Content.ReadAsStringAsync();
 
-			var unescaped = UnescapeUnicode(content);
+			var unescaped = UnicodeTools.Unescape(content);
 			var json = JObject.Parse(unescaped);
 
 			return json;
-		}
-
-		/// <summary>
-		/// unescape unicode string in C#
-		/// </summary>
-		/// <remarks>
-		/// https://stackoverflow.com/questions/8558671/how-to-unescape-unicode-string-in-c-sharp
-		/// </remarks>
-		private string UnescapeUnicode(string str)
-		{
-			return Regex.Replace(str, @"\\[Uu]([0-9A-Fa-f]{4})", m => char.ToString((char)ushort.Parse(m.Groups[1].Value, NumberStyles.AllowHexSpecifier)));
 		}
 
 		#endregion

--- a/src/BalikoBot/Internal/UnicodeTools.cs
+++ b/src/BalikoBot/Internal/UnicodeTools.cs
@@ -1,0 +1,224 @@
+﻿using System;
+
+namespace BalikoBot.Internal
+{
+    [Flags]
+    public enum UnicodeEscapeConvention
+    {
+        /// <summary>
+        /// C syntax (utf-16)
+        /// </summary>
+        C16 = 1,
+        /// <summary>
+        /// C syntax (utf-32)
+        /// </summary>
+        C32 = 2,
+    }
+
+    public class UnicodeTools
+    {
+        private const int HIGH_SURROGATE_START = 0xd800;
+        private const int LOW_SURROGATE_START = 0xdc00;
+        private const int UNICODE_PLANE01_START = 0x10000;
+
+        private static int GetHexValue(char ch)
+        {
+            switch (ch)
+            {
+                case '0': return 0;
+                case '1': return 1;
+                case '2': return 2;
+                case '3': return 3;
+                case '4': return 4;
+                case '5': return 5;
+                case '6': return 6;
+                case '7': return 7;
+                case '8': return 8;
+                case '9': return 9;
+
+                case 'a':
+                case 'A':
+                    return 0xa;
+
+                case 'b':
+                case 'B':
+                    return 0xB;
+
+                case 'c':
+                case 'C':
+                    return 0xC;
+
+                case 'd':
+                case 'D':
+                    return 0xD;
+
+                case 'e':
+                case 'E':
+                    return 0xE;
+
+                case 'f':
+                case 'F':
+                    return 0xF;
+
+                default:
+                    return -1;
+            }
+        }
+
+        private static char GetHexDigit(int value)
+        {
+            switch (value)
+            {
+                case 0: return '0';
+                case 1: return '1';
+                case 2: return '2';
+                case 3: return '3';
+                case 4: return '4';
+                case 5: return '5';
+                case 6: return '6';
+                case 7: return '7';
+                case 8: return '8';
+                case 9: return '9';
+                case 0xa: return 'a';
+                case 0xb: return 'b';
+                case 0xc: return 'c';
+                case 0xd: return 'd';
+                case 0xe: return 'e';
+                case 0xf: return 'f';
+
+                default:
+                    throw new InvalidOperationException("Invalid value");
+            }
+        }
+
+        private static bool TryParseHexInt32(string source, int index, int length, out int result)
+        {
+            result = 0;
+
+            for (var i = 0; i < length; i++)
+            {
+                var ch = source[index + i];
+
+                var value = GetHexValue(ch);
+                if (value == -1)
+                {
+                    return false;
+                }
+
+                result += value << ((length - 1 - i) * 4);
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Escape all unicode characters using C convention \uNNNN
+        /// </summary>
+        public static unsafe string Escape(string value)
+        {
+            var escapedLength = 0;
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                var ch = value[i];
+
+                if (ch < 127)
+                {
+                    escapedLength += 1;
+                }
+                else
+                {
+                    escapedLength += 6;
+                }
+            }
+
+            var result = new string('\0', escapedLength);
+
+            fixed (char* pResult = result)
+            {
+                var resultIndex = 0;
+
+                for (var i = 0; i < value.Length; i++)
+                {
+                    var ch = value[i];
+
+                    if (ch < 127)
+                    {
+                        pResult[resultIndex++] = ch;
+                    }
+                    else
+                    {
+                        var code = (ushort)ch;
+
+                        pResult[resultIndex++] = '\\';
+                        pResult[resultIndex++] = 'u';
+                        pResult[resultIndex++] = GetHexDigit((code >> 12) & 0xf);
+                        pResult[resultIndex++] = GetHexDigit((code >> 8) & 0xf);
+                        pResult[resultIndex++] = GetHexDigit((code >> 4) & 0xf);
+                        pResult[resultIndex++] = GetHexDigit(code & 0xf);
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Unescape all unicode characters using specified conventions.
+        /// </summary>
+        public static string Unescape(string value, UnicodeEscapeConvention options = UnicodeEscapeConvention.C16 | UnicodeEscapeConvention.C32)
+        {
+            var result = new char[value.Length];
+            var resultLength = 0;
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                var ch = value[i];
+
+                // remainder of input string not including current character
+                var remainder = value.Length - (i + 1);
+
+                switch (ch)
+                {
+                    // \uNNNN
+                    case '\\' when (options & UnicodeEscapeConvention.C16) == UnicodeEscapeConvention.C16 &&
+                            remainder >= 5 &&
+                            value[i + 1] == 'u' &&
+                            TryParseHexInt32(value, i + 2, 4, out var code):
+
+                        result[resultLength++] = (char)code;
+                        i += 5;
+                        break;
+
+                    // \UNNNNNNNN
+                    case '\\' when (options & UnicodeEscapeConvention.C32) == UnicodeEscapeConvention.C32 &&
+                            remainder >= 9 &&
+                            value[i + 1] == 'U' &&
+                            TryParseHexInt32(value, i + 2, 8, out var code):
+
+                        if (code < UNICODE_PLANE01_START)
+                        {
+                            result[resultLength++] = (char)code;
+                        }
+                        else
+                        {
+                            code -= UNICODE_PLANE01_START;
+
+                            result[resultLength++] = (char)((code / 0x400) + HIGH_SURROGATE_START);
+                            result[resultLength++] = (char)((code % 0x400) + LOW_SURROGATE_START);
+                        }
+
+                        i += 9;
+                        break;
+
+                    // no escaping found
+                    default:
+                        result[resultLength++] = ch;
+                        break;
+                }
+            }
+
+            return new string(result, 0, resultLength);
+        }
+    }
+}


### PR DESCRIPTION
Breaking change - regex version supported invalid format `\UNNNN`, this version requires `\U` prefix for 8 digit version `\UNNNNNNNN` and `\u` prefix for 4 digits `\uNNNN`


Benchmark for single replacement:

  Method |  Job | Runtime |        Mean |      Error |     StdDev | Ratio | RatioSD | Rank | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-------- |----- |-------- |------------:|-----------:|-----------:|------:|--------:|-----:|------------:|------------:|------------:|--------------------:|
   Regex |  Clr |     Clr | 1,048.77 ns | 20.7532 ns | 40.9648 ns |  1.00 |    0.00 |    4 |      0.3090 |           - |           - |               976 B |
 Loop_16 |  Clr |     Clr |    36.85 ns |  0.8045 ns |  0.9577 ns |  0.03 |    0.00 |    1 |      0.0228 |           - |           - |                72 B |
 Loop_32 |  Clr |     Clr |    37.67 ns |  0.8440 ns |  1.5433 ns |  0.04 |    0.00 |    1 |      0.0228 |           - |           - |                72 B |
   Regex | Core |    Core |   856.17 ns | 12.0266 ns | 11.2497 ns |  0.80 |    0.04 |    3 |      0.1974 |           - |           - |               624 B |
 Loop_16 | Core |    Core |    39.20 ns |  0.8530 ns |  1.5382 ns |  0.04 |    0.00 |    2 |      0.0228 |           - |           - |                72 B |
 Loop_32 | Core |    Core |    37.41 ns |  0.8348 ns |  0.7400 ns |  0.04 |    0.00 |    1 |      0.0228 |           - |           - |                72 B |

Benchmark for 50 replacements:

  Method |  Job | Runtime |      Mean |     Error |    StdDev | Ratio | RatioSD | Rank | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-------- |----- |-------- |----------:|----------:|----------:|------:|--------:|-----:|------------:|------------:|------------:|--------------------:|
   Regex |  Clr |     Clr | 33.824 us | 0.3599 us | 0.3191 us |  1.00 |    0.00 |    2 |      8.0566 |           - |           - |             25521 B |
   Regex | Core |    Core | 32.855 us | 0.7109 us | 0.6302 us |  0.97 |    0.02 |    1 |      7.8125 |           - |           - |             24728 B |
 Loop_16 |  Clr |     Clr |  1.080 us | 0.0210 us | 0.0327 us |  1.00 |    0.00 |    1 |      0.3014 |           - |           - |               952 B |
 Loop_16 | Core |    Core |  1.118 us | 0.0239 us | 0.0392 us |  1.04 |    0.05 |    2 |      0.3014 |           - |           - |               952 B |
 Loop_32 |  Clr |     Clr |  1.988 us | 0.0409 us | 0.0471 us |  1.00 |    0.00 |    1 |      0.4616 |           - |           - |              1456 B |
 Loop_32 | Core |    Core |  1.987 us | 0.0389 us | 0.0532 us |  1.00 |    0.04 |    1 |      0.4616 |           - |           - |              1456 B |